### PR TITLE
fix install.sh not installing snapsync.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,8 +10,8 @@ GEMFILE
 bundler install --standalone --binstubs
 if test -d /opt/snapsync; then
     sudo rm -rf /opt/snapsync
-    sudo cp -r . /opt/snapsync
 fi
+sudo cp -r . /opt/snapsync
 
 if test -d /lib/systemd/system; then
     snapsync_gem=`bundler show snapsync`
@@ -22,4 +22,3 @@ if test -d /lib/systemd/system; then
 fi
 
 rm -rf $target
-


### PR DESCRIPTION
When there was no previous installation of snapsync, the install.sh script didn't move any files to `/opt/snapsync`.
