### PR TITLE
Enhancement: Allow all block devices with filesystems

### DIFF
--- a/lib/snapsync/partitions_monitor.rb
+++ b/lib/snapsync/partitions_monitor.rb
@@ -116,7 +116,7 @@ module Snapsync
             return enum_for(__method__) if !block_given?
             udisk.root['org']['freedesktop']['UDisks2']['block_devices'].each do |device_name, _|
                 dev = udisk.object("/org/freedesktop/UDisks2/block_devices/#{device_name}")
-                if dev['org.freedesktop.UDisks2.Partition'] && dev['org.freedesktop.UDisks2.Filesystem']
+                if dev['org.freedesktop.UDisks2.Block'] && dev['org.freedesktop.UDisks2.Filesystem']
                     yield(device_name, dev)
                 end
             end


### PR DESCRIPTION
First, thanks for creating such an awesome project.

This one-line PR allows backups to all block devices with valid filesystems, not just physical partitions. This is needed for dm-crypt devices to work, since they are mappers, not partitions.

Without the patch, snapsync will ignore these mapper devices. For example, `snapsync auto-add` will fail to guess the device UUID and `snapsync auto-sync` will just ignore these devices silently.

I think it is safe to make those changes since `dev['org.freedesktop.UDisks2.Partition']` isn't used anywhere else in the project. All information such as UUID is accessed through `dev['org.freedesktop.UDisks2.Block']`. Please correct me if I'm wrong.

Example commands to work with a dm-crypt enabled partition:

```bash
cryptsetup open /dev/sdXY foo
mount /dev/mapper/foo /mnt
snapsync auto-add foo /mnt
snapsync auto-sync
```

As a side-note, auto-mounting won't work of course, unless the dm-crypt device has been opened by `cryptsetup open`.