### PR TITLE
attempt to fix "first snapshot is not read-only" issue

### DIFF
--- a/lib/snapsync/btrfs.rb
+++ b/lib/snapsync/btrfs.rb
@@ -81,6 +81,19 @@ module Snapsync
             end
         end
 
+        # Facade for checking readonly-flag on snapshot using 'btrfs subvolume show'
+        #
+        # @param [Pathname] path the subvolume path
+        # @return [Boolean] if the snapshot is readonly
+        def self.readonly(path)
+            info = Btrfs.run('subvolume', 'show', path.to_s)
+            if info =~ /Flags[^:]*:\s+(-|\w+)/
+                "readonly" == $1.to_s
+            else
+                raise UnexpectedBtrfsOutput, "unexpected output for 'btrfs subvolume show', expected #{info} to contain a Flags: line"
+            end
+        end
+
         # Facade for 'btrfs subvolume find-new'
         #
         # It computes what changed between a reference generation of a

--- a/lib/snapsync/snapshot.rb
+++ b/lib/snapsync/snapshot.rb
@@ -117,7 +117,12 @@ module Snapsync
                 if path.directory? && path.basename.to_s =~ /^\d+$/
                     begin
                         snapshot = Snapshot.new(path)
-                        yield(path, snapshot, nil)
+			readonly = Btrfs.readonly(snapshot.subvolume_dir())
+			if readonly
+                            yield(path, snapshot, nil)
+			else
+			    Snapsync.info "found non-read-only snapshot #{path}"
+                        end
                     rescue InvalidSnapshot => e
                         yield(path, nil, e)
                     end


### PR DESCRIPTION
It did a work for me, but the first snapshots, which was synchronized was not the correct one. Some snapshots were skipped. I've modified each()-Method of Snapshot class. It would be better to skip a writable snapshot and take the next one at the time of synchronization. But I couldn't find a correct place for the check quick enough.